### PR TITLE
Add library alias for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME}
     qtaskbarcontrol.cpp
     qtaskbarcontrol_p.cpp
 )
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Widgets)


### PR DESCRIPTION
I added a library alias as in [QHotkey](https://github.com/Skycoder42/QHotkey/blob/0352904ec175216e7fdc4138f6aa3bcd7f0250b1/CMakeLists.txt#L40) just for consistency.