### PR TITLE
Fix members overwriting

### DIFF
--- a/qtaskbarcontrol.cpp
+++ b/qtaskbarcontrol.cpp
@@ -84,14 +84,14 @@ void QTaskbarControl::setWindowsBadgeTextColor(const QColor &color)
 	d->setWindowsBadgeTextColor(color);
 }
 
-void QTaskbarControl::setProgressVisible(bool progressVisible)
+void QTaskbarControl::setProgressVisible(bool visible)
 {
-	if (d->progressVisible == progressVisible)
+	if (d->progressVisible == visible)
 		return;
 
-	d->progressVisible = progressVisible;
-	d->setProgress(progressVisible, d->progress);
-	emit progressVisibleChanged(progressVisible);
+	d->progressVisible = visible;
+	d->setProgress(visible, d->progress);
+	emit progressVisibleChanged(visible);
 }
 
 void QTaskbarControl::setProgress(double progress)
@@ -104,24 +104,24 @@ void QTaskbarControl::setProgress(double progress)
 	emit progressChanged(progress);
 }
 
-void QTaskbarControl::setCounterVisible(bool counterVisible)
+void QTaskbarControl::setCounterVisible(bool visible)
 {
-	if (d->counterVisible == counterVisible)
+	if (d->counterVisible == visible)
 		return;
 
-	d->counterVisible = counterVisible;
-	d->setCounter(counterVisible, d->counter);
-	emit counterVisibleChanged(counterVisible);
+	d->counterVisible = visible;
+	d->setCounter(visible, d->counter);
+	emit counterVisibleChanged(visible);
 }
 
-void QTaskbarControl::setCounter(int counter)
+void QTaskbarControl::setCounter(int value)
 {
-	if (d->counter == counter)
+	if (d->counter == value)
 		return;
 
-	d->counter = counter;
-	d->setCounter(d->counterVisible, counter);
-	emit counterChanged(counter);
+	d->counter = value;
+	d->setCounter(d->counterVisible, value);
+	emit counterChanged(value);
 }
 
 bool QTaskbarControl::eventFilter(QObject *watched, QEvent *event)

--- a/qtaskbarcontrol.h
+++ b/qtaskbarcontrol.h
@@ -41,16 +41,16 @@ public slots:
 	void setWindowsProgressState(WinProgressState state);
 	void setWindowsBadgeIcon(const QIcon &icon);
 	void setWindowsBadgeTextColor(const QColor &color);
-	void setProgressVisible(bool progressVisible);
+	void setProgressVisible(bool visible);
 	void setProgress(double progress);
-	void setCounterVisible(bool counterVisible);
-	void setCounter(int counter);
+	void setCounterVisible(bool visible);
+	void setCounter(int value);
 
 signals:
-	void progressVisibleChanged(bool progressVisible);
+	void progressVisibleChanged(bool visible);
 	void progressChanged(double progress);
-	void counterVisibleChanged(bool counterVisible);
-	void counterChanged(int counter);
+	void counterVisibleChanged(bool visible);
+	void counterChanged(int value);
 
 private:
 	QScopedPointer<QTaskbarControlPrivate> d;

--- a/qtaskbarcontrol_dummy.cpp
+++ b/qtaskbarcontrol_dummy.cpp
@@ -5,14 +5,14 @@ QTaskbarControlPrivate *QTaskbarControlPrivate::createPrivate(QTaskbarControl *)
 	return new QDummyTaskbarControl{};
 }
 
-void QDummyTaskbarControl::setProgress(bool progressVisible, double progress)
+void QDummyTaskbarControl::setProgress(bool visible, double progress)
 {
-	Q_UNUSED(progressVisible)
+	Q_UNUSED(visible)
 	Q_UNUSED(progress)
 }
 
-void QDummyTaskbarControl::setCounter(bool counterVisible, int counter)
+void QDummyTaskbarControl::setCounter(bool visible, int value)
 {
-	Q_UNUSED(counterVisible)
-	Q_UNUSED(counter)
+	Q_UNUSED(visible)
+	Q_UNUSED(value)
 }

--- a/qtaskbarcontrol_dummy.h
+++ b/qtaskbarcontrol_dummy.h
@@ -7,8 +7,8 @@ class QDummyTaskbarControl : public QTaskbarControlPrivate
 {
 public:
 	// QTaskbarControlPrivate interface
-	void setProgress(bool progressVisible, double progress) override;
-	void setCounter(bool counterVisible, int counter) override;
+	void setProgress(bool visible, double progress) override;
+	void setCounter(bool visible, int value) override;
 };
 
 #endif // QTASKBARCONTROL_DUMMY_H

--- a/qtaskbarcontrol_mac.h
+++ b/qtaskbarcontrol_mac.h
@@ -19,8 +19,8 @@ public:
 	QMacTaskbarControl();
 	~QMacTaskbarControl();
 
-	void setProgress(bool progressVisible, double progress) override;
-	void setCounter(bool counterVisible, int counter) override;
+	void setProgress(bool visible, double progress) override;
+	void setCounter(bool visible, int value) override;
 
 private:
 	TaskProgressView *_taskView;

--- a/qtaskbarcontrol_mac.mm
+++ b/qtaskbarcontrol_mac.mm
@@ -73,20 +73,20 @@ QMacTaskbarControl::~QMacTaskbarControl()
 	[_taskView release];
 }
 
-void QMacTaskbarControl::setProgress(bool progressVisible, double progress)
+void QMacTaskbarControl::setProgress(bool visible, double progress)
 {
 	[_taskView setProgress:progress];
-	if (progressVisible && progress >= 0.0)
+	if (visible && progress >= 0.0)
 		[[NSApp dockTile] setContentView:_taskView];
 	else
 		[[NSApp dockTile] setContentView:nil];
 	[[NSApp dockTile] display];
 }
 
-void QMacTaskbarControl::setCounter(bool counterVisible, int counter)
+void QMacTaskbarControl::setCounter(bool visible, int value)
 {
-	if(counterVisible)
-		QtMac::setBadgeLabelText(QLocale().toString(counter));
+	if(visible)
+		QtMac::setBadgeLabelText(QLocale().toString(value));
 	else
 		QtMac::setBadgeLabelText(QString());
 }

--- a/qtaskbarcontrol_p.h
+++ b/qtaskbarcontrol_p.h
@@ -23,8 +23,8 @@ public:
 	virtual QIcon windowsBadgeIcon() const;
 	virtual void setWindowsBadgeTextColor(const QColor &color);
 	virtual QColor windowsBadgeTextColor() const;
-	virtual void setProgress(bool progressVisible, double progress) = 0;
-	virtual void setCounter(bool counterVisible, int counter) = 0;
+	virtual void setProgress(bool visible, double progress) = 0;
+	virtual void setCounter(bool visible, int value) = 0;
 
 private:
 	QPointer<QWidget> watchedWidget;

--- a/qtaskbarcontrol_win.cpp
+++ b/qtaskbarcontrol_win.cpp
@@ -69,7 +69,7 @@ QColor QWinTaskbarControl::windowsBadgeTextColor() const
 	return _badgeColor;
 }
 
-void QWinTaskbarControl::setProgress(bool progressVisible, double progress)
+void QWinTaskbarControl::setProgress(bool visible, double progress)
 {
 	if(progress < 0)
 		_button->progress()->setRange(0, 0);
@@ -77,14 +77,14 @@ void QWinTaskbarControl::setProgress(bool progressVisible, double progress)
 		_button->progress()->setRange(0, 1000);
 		_button->progress()->setValue(static_cast<int>(progress * 1000));
 	}
-	_button->progress()->setVisible(progressVisible);
+	_button->progress()->setVisible(visible);
 }
 
-void QWinTaskbarControl::setCounter(bool counterVisible, int counter)
+void QWinTaskbarControl::setCounter(bool visible, int visible)
 {
-	if(counterVisible) {
+	if(visible) {
 		QIcon currentBadge;
-		auto text = QLocale{}.toString(counter);
+		auto text = QLocale{}.toString(visible);
 
 		foreach(auto size, _badgeIcon.availableSizes()) {
 			auto pm = _badgeIcon.pixmap(size);

--- a/qtaskbarcontrol_win.h
+++ b/qtaskbarcontrol_win.h
@@ -18,8 +18,8 @@ public:
 	QIcon windowsBadgeIcon() const override;
 	void setWindowsBadgeTextColor(const QColor &color) override;
 	QColor windowsBadgeTextColor() const override;
-	void setProgress(bool progressVisible, double progress) override;
-	void setCounter(bool counterVisible, int counter) override;
+	void setProgress(bool visible, double progress) override;
+	void setCounter(bool visible, int counter) override;
 
 private:
 	QTaskbarControl *_q_ptr;

--- a/qtaskbarcontrol_x11.cpp
+++ b/qtaskbarcontrol_x11.cpp
@@ -9,19 +9,19 @@ QTaskbarControlPrivate *QTaskbarControlPrivate::createPrivate(QTaskbarControl *)
 	return new QX11TaskbarControl{};
 }
 
-void QX11TaskbarControl::setProgress(bool progressVisible, double progress)
+void QX11TaskbarControl::setProgress(bool visible, double progress)
 {
 	QVariantMap properties;
-	properties.insert(QStringLiteral("progress-visible"), progressVisible);
+	properties.insert(QStringLiteral("progress-visible"), visible);
 	properties.insert(QStringLiteral("progress"), progress);
 	sendMessage(properties);
 }
 
-void QX11TaskbarControl::setCounter(bool counterVisible, int counter)
+void QX11TaskbarControl::setCounter(bool visible, int value)
 {
 	QVariantMap properties;
-	properties.insert(QStringLiteral("count-visible"), counterVisible);
-	properties.insert(QStringLiteral("count"), counter);
+	properties.insert(QStringLiteral("count-visible"), visible);
+	properties.insert(QStringLiteral("count"), value);
 	sendMessage(properties);
 }
 

--- a/qtaskbarcontrol_x11.h
+++ b/qtaskbarcontrol_x11.h
@@ -7,8 +7,8 @@ class QX11TaskbarControl : public QTaskbarControlPrivate
 {
 public:
 	// QTaskbarControlPrivate interface
-	void setProgress(bool progressVisible, double progress) override;
-	void setCounter(bool counterVisible, int counter) override;
+	void setProgress(bool visible, double progress) override;
+	void setCounter(bool visible, int value) override;
 
 private:
 	void sendMessage(const QVariantMap &params);


### PR DESCRIPTION
This PR fixes the following MSVC warnings:

```
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_win.cpp(72,43): error C2220: the following warning is treated as an error [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_win.cpp(72,43): warning C4458: declaration of 'progressVisible' hides class member [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_p.h(31,7): message : see declaration of 'QTaskbarControlPrivate::progressVisible' [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_win.cpp(72,67): warning C4458: declaration of 'progress' hides class member [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_p.h(32,9): message : see declaration of 'QTaskbarControlPrivate::progress' [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_win.cpp(83,42): warning C4458: declaration of 'counterVisible' hides class member [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_p.h(33,7): message : see declaration of 'QTaskbarControlPrivate::counterVisible' [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_win.cpp(83,62): warning C4458: declaration of 'counter' hides class member [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
D:\a\crow-translate\crow-translate\src\third-party\qtaskbarcontrol\qtaskbarcontrol_p.h(34,6): message : see declaration of 'QTaskbarControlPrivate::counter' [D:\a\crow-translate\crow-translate\build\src\third-party\qtaskbarcontrol\QTaskbarControl.vcxproj]
```

I renamed function parameters `progressVisible` and `counterVisible` to `visible` and `counter` to `value`.