### PR TITLE
Fix typo after refactoring

### DIFF
--- a/qtaskbarcontrol.cpp
+++ b/qtaskbarcontrol.cpp
@@ -94,14 +94,14 @@ void QTaskbarControl::setProgressVisible(bool visible)
 	emit progressVisibleChanged(visible);
 }
 
-void QTaskbarControl::setProgress(double progress)
+void QTaskbarControl::setProgress(double value)
 {
-	if (qFuzzyCompare(d->progress, progress))
+	if (qFuzzyCompare(d->progress, value))
 		return;
 
-	d->progress = progress;
-	d->setProgress(d->progressVisible, progress);
-	emit progressChanged(progress);
+	d->progress = value;
+	d->setProgress(d->progressVisible, value);
+	emit progressChanged(value);
 }
 
 void QTaskbarControl::setCounterVisible(bool visible)

--- a/qtaskbarcontrol.h
+++ b/qtaskbarcontrol.h
@@ -42,13 +42,13 @@ public slots:
 	void setWindowsBadgeIcon(const QIcon &icon);
 	void setWindowsBadgeTextColor(const QColor &color);
 	void setProgressVisible(bool visible);
-	void setProgress(double progress);
+	void setProgress(double value);
 	void setCounterVisible(bool visible);
 	void setCounter(int value);
 
 signals:
 	void progressVisibleChanged(bool visible);
-	void progressChanged(double progress);
+	void progressChanged(double value);
 	void counterVisibleChanged(bool visible);
 	void counterChanged(int value);
 

--- a/qtaskbarcontrol_dummy.cpp
+++ b/qtaskbarcontrol_dummy.cpp
@@ -5,10 +5,10 @@ QTaskbarControlPrivate *QTaskbarControlPrivate::createPrivate(QTaskbarControl *)
 	return new QDummyTaskbarControl{};
 }
 
-void QDummyTaskbarControl::setProgress(bool visible, double progress)
+void QDummyTaskbarControl::setProgress(bool visible, double value)
 {
 	Q_UNUSED(visible)
-	Q_UNUSED(progress)
+	Q_UNUSED(value)
 }
 
 void QDummyTaskbarControl::setCounter(bool visible, int value)

--- a/qtaskbarcontrol_dummy.h
+++ b/qtaskbarcontrol_dummy.h
@@ -7,7 +7,7 @@ class QDummyTaskbarControl : public QTaskbarControlPrivate
 {
 public:
 	// QTaskbarControlPrivate interface
-	void setProgress(bool visible, double progress) override;
+	void setProgress(bool visible, double value) override;
 	void setCounter(bool visible, int value) override;
 };
 

--- a/qtaskbarcontrol_mac.h
+++ b/qtaskbarcontrol_mac.h
@@ -9,7 +9,7 @@
 	double _progress;
 }
 
-- (void)setProgress:(double)progress;
+- (void)setProgress:(double)value;
 
 @end
 
@@ -19,7 +19,7 @@ public:
 	QMacTaskbarControl();
 	~QMacTaskbarControl();
 
-	void setProgress(bool visible, double progress) override;
+	void setProgress(bool visible, double value) override;
 	void setCounter(bool visible, int value) override;
 
 private:

--- a/qtaskbarcontrol_mac.mm
+++ b/qtaskbarcontrol_mac.mm
@@ -11,9 +11,9 @@
 
 @implementation TaskProgressView
 
-- (void)setProgress:(double)progress
+- (void)setProgress:(double)value
 {
-	_progress = progress;
+	_progress = value;
 }
 
 - (void)drawRect:(NSRect)rect
@@ -73,10 +73,10 @@ QMacTaskbarControl::~QMacTaskbarControl()
 	[_taskView release];
 }
 
-void QMacTaskbarControl::setProgress(bool visible, double progress)
+void QMacTaskbarControl::setProgress(bool visible, double value)
 {
-	[_taskView setProgress:progress];
-	if (visible && progress >= 0.0)
+	[_taskView setProgress:value];
+	if (visible && value >= 0.0)
 		[[NSApp dockTile] setContentView:_taskView];
 	else
 		[[NSApp dockTile] setContentView:nil];

--- a/qtaskbarcontrol_p.h
+++ b/qtaskbarcontrol_p.h
@@ -23,7 +23,7 @@ public:
 	virtual QIcon windowsBadgeIcon() const;
 	virtual void setWindowsBadgeTextColor(const QColor &color);
 	virtual QColor windowsBadgeTextColor() const;
-	virtual void setProgress(bool visible, double progress) = 0;
+	virtual void setProgress(bool visible, double value) = 0;
 	virtual void setCounter(bool visible, int value) = 0;
 
 private:

--- a/qtaskbarcontrol_win.cpp
+++ b/qtaskbarcontrol_win.cpp
@@ -69,13 +69,13 @@ QColor QWinTaskbarControl::windowsBadgeTextColor() const
 	return _badgeColor;
 }
 
-void QWinTaskbarControl::setProgress(bool visible, double progress)
+void QWinTaskbarControl::setProgress(bool visible, double value)
 {
-	if(progress < 0)
+	if(value < 0)
 		_button->progress()->setRange(0, 0);
 	else {
 		_button->progress()->setRange(0, 1000);
-		_button->progress()->setValue(static_cast<int>(progress * 1000));
+		_button->progress()->setValue(static_cast<int>(value * 1000));
 	}
 	_button->progress()->setVisible(visible);
 }

--- a/qtaskbarcontrol_win.cpp
+++ b/qtaskbarcontrol_win.cpp
@@ -80,11 +80,11 @@ void QWinTaskbarControl::setProgress(bool visible, double progress)
 	_button->progress()->setVisible(visible);
 }
 
-void QWinTaskbarControl::setCounter(bool visible, int visible)
+void QWinTaskbarControl::setCounter(bool visible, int value)
 {
 	if(visible) {
 		QIcon currentBadge;
-		auto text = QLocale{}.toString(visible);
+		auto text = QLocale{}.toString(value);
 
 		foreach(auto size, _badgeIcon.availableSizes()) {
 			auto pm = _badgeIcon.pixmap(size);

--- a/qtaskbarcontrol_win.h
+++ b/qtaskbarcontrol_win.h
@@ -18,7 +18,7 @@ public:
 	QIcon windowsBadgeIcon() const override;
 	void setWindowsBadgeTextColor(const QColor &color) override;
 	QColor windowsBadgeTextColor() const override;
-	void setProgress(bool visible, double progress) override;
+	void setProgress(bool visible, double value) override;
 	void setCounter(bool visible, int value) override;
 
 private:

--- a/qtaskbarcontrol_win.h
+++ b/qtaskbarcontrol_win.h
@@ -19,7 +19,7 @@ public:
 	void setWindowsBadgeTextColor(const QColor &color) override;
 	QColor windowsBadgeTextColor() const override;
 	void setProgress(bool visible, double progress) override;
-	void setCounter(bool visible, int counter) override;
+	void setCounter(bool visible, int value) override;
 
 private:
 	QTaskbarControl *_q_ptr;

--- a/qtaskbarcontrol_x11.cpp
+++ b/qtaskbarcontrol_x11.cpp
@@ -9,11 +9,11 @@ QTaskbarControlPrivate *QTaskbarControlPrivate::createPrivate(QTaskbarControl *)
 	return new QX11TaskbarControl{};
 }
 
-void QX11TaskbarControl::setProgress(bool visible, double progress)
+void QX11TaskbarControl::setProgress(bool visible, double value)
 {
 	QVariantMap properties;
 	properties.insert(QStringLiteral("progress-visible"), visible);
-	properties.insert(QStringLiteral("progress"), progress);
+	properties.insert(QStringLiteral("progress"), value);
 	sendMessage(properties);
 }
 

--- a/qtaskbarcontrol_x11.h
+++ b/qtaskbarcontrol_x11.h
@@ -7,7 +7,7 @@ class QX11TaskbarControl : public QTaskbarControlPrivate
 {
 public:
 	// QTaskbarControlPrivate interface
-	void setProgress(bool visible, double progress) override;
+	void setProgress(bool visible, double value) override;
 	void setCounter(bool visible, int value) override;
 
 private:


### PR DESCRIPTION
I made a typo in #6, sorry :)
Also found that `progress` should be renamed into `value` too (also causes warnings).