### PR TITLE
Fix Clang Tidy warnings

### DIFF
--- a/qtaskbarcontrol.cpp
+++ b/qtaskbarcontrol.cpp
@@ -127,7 +127,7 @@ void QTaskbarControl::setCounter(int value)
 bool QTaskbarControl::eventFilter(QObject *watched, QEvent *event)
 {
 	if (event->type() == QEvent::Show) {
-		auto widget = qobject_cast<QWidget*>(watched);
+		auto *widget = qobject_cast<QWidget*>(watched);
 		if (widget)
 			setWindow(widget->windowHandle());
 	}

--- a/qtaskbarcontrol_x11.h
+++ b/qtaskbarcontrol_x11.h
@@ -11,7 +11,7 @@ public:
 	void setCounter(bool visible, int value) override;
 
 private:
-	void sendMessage(const QVariantMap &params);
+	static void sendMessage(const QVariantMap &params);
 };
 
 #endif // QTASKBARCONTROL_X11_H


### PR DESCRIPTION
I fixed the following Clang Tidy warnings (found on my CI):
[readability-convert-member-functions-to-static](https://clang.llvm.org/extra/clang-tidy/checks/readability-convert-member-functions-to-static.html)
[readability-qualified-auto](https://clang.llvm.org/extra/clang-tidy/checks/readability-qualified-auto.html)