### PR TITLE
Use fully qualified MOC types

### DIFF
--- a/qtaskbarcontrol.h
+++ b/qtaskbarcontrol.h
@@ -38,7 +38,7 @@ public:
 	int counter() const;
 
 public slots:
-	void setWindowsProgressState(WinProgressState state);
+	void setWindowsProgressState(QTaskbarControl::WinProgressState state);
 	void setWindowsBadgeIcon(const QIcon &icon);
 	void setWindowsBadgeTextColor(const QColor &color);
 	void setProgressVisible(bool visible);


### PR DESCRIPTION
One small Clazy suggestion.
[fully-qualified-moc-types](https://github.com/KDE/clazy/blob/master/docs/checks/README-fully-qualified-moc-types.md)